### PR TITLE
fixed manage_requests

### DIFF
--- a/server/templates/server/manage_requests.html
+++ b/server/templates/server/manage_requests.html
@@ -34,7 +34,7 @@
     </thead>
     <tbody>
         {% for the_request in requests %}
-        <tr><td><a href="{% url 'approve' the_request.id %}">{{ the_request.computer.serial }}</a></td><td><a href="{% url 'approve' the_request.id %}">{{ the_request.computer.computername }}</a></td><td>{{ the_request.requesting_user }}</td><td>{{ the_request.reason_for_request }}</td><td>{{ the_request.date_requested }}</td><td><a class="btn btn-primary btn-mini" href="{% url 'approve' the_request.id %}">Manage</a></td></tr>
+        <tr><td><a href="{% url 'approve' the_request.id %}">{{ the_request.secret.computer.serial }}</a></td><td><a href="{% url 'approve' the_request.id %}">{{ the_request.secret.computer.computername }}</a></td><td>{{ the_request.requesting_user }}</td><td>{{ the_request.reason_for_request }}</td><td>{{ the_request.date_requested }}</td><td><a class="btn btn-primary btn-mini" href="{% url 'approve' the_request.id %}">Manage</a></td></tr>
         {% endfor %}
     </tbody>
 </table>


### PR DESCRIPTION
when secrets were split into their own model, the manage requests page broke in that computer name and serial weren’t referenced correctly, this change corrects that issue