### PR TITLE
Add secret_type to checkin view

### DIFF
--- a/server/views.py
+++ b/server/views.py
@@ -234,7 +234,7 @@ def checkin(request):
     computer.secret_type = secret_type
     computer.save()
 
-    secret = Secret(computer=computer, secret=recovery_pass, date_escrowed=datetime.now())
+    secret = Secret(computer=computer, secret=recovery_pass, secret_type=secret_type, date_escrowed=datetime.now())
     secret.save()
 
     c ={'revovery_password':secret.secret, 'serial':computer.serial, 'username':computer.username, }


### PR DESCRIPTION
Secret object was using default 'recovery_key' type because it wasn't being assigned before creation/save, after being pulled from POST'd escrow.