### PR TITLE
do not force wheel in the pip reqs

### DIFF
--- a/setup/requirements.txt
+++ b/setup/requirements.txt
@@ -1,5 +1,4 @@
 Django==1.8.3
-wheel==0.24.0
 docutils==0.11
 wsgiref==0.1.2
 django-extensions==1.5.5


### PR DESCRIPTION
so when running this fully isolated under its own user if there happens to be a version of wheel already installed pip install breaks because it can not remove it.  This pull fixes that

```
       Installing collected packages: Django, wheel, docutils, six, django-extensions, pyasn1, pycrypto, python-keyczar, django-bootstrap3
         Found existing installation: wheel 0.29.0
           Uninstalling wheel-0.29.0:
       STDERR: /usr/local/crypt/.env/local/lib/python2.7/site-packages/pip/_vendor/requests/packages/urllib3/util/ssl_.py:318: SNIMissingWarning: An HTTPS request has been made, but the SNI (Subject Name Indication) extension to TLS is not available on this platform. This may cause the server to present an incorrect TLS certificate, which can cause validation failures. You can upgrade to a newer version of Python to solve this. For more information, see https://urllib3.readthedocs.org/en/latest/security.html#snimissingwarning.
         SNIMissingWarning
       /usr/local/crypt/.env/local/lib/python2.7/site-packages/pip/_vendor/requests/packages/urllib3/util/ssl_.py:122: InsecurePlatformWarning: A true SSLContext object is not available. This prevents urllib3 from configuring SSL appropriately and may cause certain SSL connections to fail. You can upgrade to a newer version of Python to solve this. For more information, see https://urllib3.readthedocs.org/en/latest/security.html#insecureplatformwarning.
         InsecurePlatformWarning
       Exception:
       Traceback (most recent call last):
         File "/usr/local/crypt/.env/local/lib/python2.7/site-packages/pip/basecommand.py", line 215, in main
           status = self.run(options, args)
         File "/usr/local/crypt/.env/local/lib/python2.7/site-packages/pip/commands/install.py", line 317, in run
           prefix=options.prefix_path,
         File "/usr/local/crypt/.env/local/lib/python2.7/site-packages/pip/req/req_set.py", line 736, in install
           requirement.uninstall(auto_confirm=True)
         File "/usr/local/crypt/.env/local/lib/python2.7/site-packages/pip/req/req_install.py", line 742, in uninstall
           paths_to_remove.remove(auto_confirm)
         File "/usr/local/crypt/.env/local/lib/python2.7/site-packages/pip/req/req_uninstall.py", line 115, in remove
           renames(path, new_path)
         File "/usr/local/crypt/.env/local/lib/python2.7/site-packages/pip/utils/__init__.py", line 267, in renames
           shutil.move(old, new)
         File "/usr/lib/python2.7/shutil.py", line 303, in move
           os.unlink(src)
       OSError: [Errno 13] Permission denied: '/usr/local/crypt/.env/lib/python2.7/site-packages/wheel-0.29.0.dist-info/DESCRIPTION.rst'
       ---- End output of ["/usr/local/crypt/.env/bin/python", "-m", "pip.__main__", "install", "--requirement", "/usr/local/crypt/setup/requirements.txt"] ----
       Ran ["/usr/local/crypt/.env/bin/python", "-m", "pip.__main__", "install", "--requirement", "/usr/local/crypt/setup/requirements.txt"] returned 2
```