### PR TITLE
Update Docker.md - add instruction to create new empty file for sqlite db first

### DIFF
--- a/docs/Docker.md
+++ b/docs/Docker.md
@@ -1,7 +1,12 @@
 # Using Docker
 
-## Basic usage
+## Prepare for first use
+When starting from scratch, create a new empty file on the docker host to hold the sqlite3 secrets database
+``` bash
+touch /somewhere/else/on/the/host
+```
 
+## Basic usage
 ``` bash
 docker run -d --name="Crypt" \
 --restart="always" \


### PR DESCRIPTION
add paragraph to prep for first use with sqlite empty file, needed to avoid 502 bad gateway which occurs if docker mounts a folder where crypt needs a file for the crypt.db