### PR TITLE
Add styling to key retrieval

### DIFF
--- a/server/templates/server/retrieve.html
+++ b/server/templates/server/retrieve.html
@@ -27,7 +27,21 @@
 
 <div class="row">
     <div class="col-sm-6 col-md-6">
-        <p><strong>{{ the_request.secret.get_secret_type_display }}:</strong><br /><code>{{ the_request.secret.secret }}</code></p>
+        <p><strong>{{ the_request.secret.get_secret_type_display }}:</strong><br />
+        <code>
+        {% spaceless %}
+        {% for char in the_request.secret.secret %}
+            {% if char in "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ" %}
+                <span class="letter">{{ char }}</span>
+            {% elif char in "0123456789" %}
+                <span class="number">{{ char }}</span>
+            {% else %}
+                <span class="other">{{ char }}</span>
+            {% endif %}
+        {% endfor %}
+        {% endspaceless %}
+        </code>
+        </p>
 
         <p>This approval is valid for 7 days, after which you will need to submit another request for access.</p>
     </div>

--- a/site_static/style.css
+++ b/site_static/style.css
@@ -4,3 +4,22 @@ h1, h2, h3, h4, h5, h6, h3 a{
 	font-weight:normal;
 	color: black;
 }
+
+code {
+    background-color: #444;
+    padding: 5px;
+}
+code span {
+    padding-left: 2px;
+    padding-right: 2px;
+    font-size: 1.25em;
+}
+code span.letter {
+    color: #fff;
+}
+code span.number {
+    color: #a1bcea;
+}
+code span.other {
+    color: #f2a5bd;
+}


### PR DESCRIPTION
Added formatting to differentiate between letters, numbers, and symbols. Works for recovery keys and passwords (and anything else that you could pull for the retrieval page).

![image](https://user-images.githubusercontent.com/7746625/39071597-ab731ef2-44b5-11e8-84fc-955468641af9.png)
![image](https://user-images.githubusercontent.com/7746625/39071559-8694b5f0-44b5-11e8-942b-ca811685dfda.png)
