### PR TITLE
Sort by last checkin

### DIFF
--- a/server/templates/server/index.html
+++ b/server/templates/server/index.html
@@ -48,7 +48,7 @@
     </thead>
     <tbody>
         {% for computer in computers.all %}
-        <tr><td><a href="{% url 'computer_info' computer.id %}">{{ computer.serial }}</a></td><td><a href="{% url 'computer_info' computer.id %}">{{ computer.computername }}</a></td><td>{{ computer.username }}</td><td>{{ computer.last_checkin|date:"c" }}</td><td><a class="btn btn-info btn-xs" href="{% url 'computer_info' computer.id %}">Info</a></td></tr>
+        <tr><td><a href="{% url 'computer_info' computer.id %}">{{ computer.serial }}</a></td><td><a href="{% url 'computer_info' computer.id %}">{{ computer.computername }}</a></td><td>{{ computer.username }}</td><td>{{ computer.last_checkin|date:"Y-m-d H:i:s" }}</td><td><a class="btn btn-info btn-xs" href="{% url 'computer_info' computer.id %}">Info</a></td></tr>
         {% endfor %}
         </tbody>
 </table>

--- a/server/templates/server/index.html
+++ b/server/templates/server/index.html
@@ -9,7 +9,7 @@
             "aLengthMenu": [[20, 50, -1], [20, 50, "All"]],
             // "sPaginationType": "bootstrap",
             // "bStateSave": true,
-            // "aaSorting": [[1,'asc']]
+             "aaSorting": [[3,'desc']]
         });
     } );
 </script>
@@ -48,7 +48,7 @@
     </thead>
     <tbody>
         {% for computer in computers.all %}
-        <tr><td><a href="{% url 'computer_info' computer.id %}">{{ computer.serial }}</a></td><td><a href="{% url 'computer_info' computer.id %}">{{ computer.computername }}</a></td><td>{{ computer.username }}</td><td>{{ computer.last_checkin }}</td><td><a class="btn btn-info btn-xs" href="{% url 'computer_info' computer.id %}">Info</a></td></tr>
+        <tr><td><a href="{% url 'computer_info' computer.id %}">{{ computer.serial }}</a></td><td><a href="{% url 'computer_info' computer.id %}">{{ computer.computername }}</a></td><td>{{ computer.username }}</td><td>{{ computer.last_checkin|date:"c" }}</td><td><a class="btn btn-info btn-xs" href="{% url 'computer_info' computer.id %}">Info</a></td></tr>
         {% endfor %}
         </tbody>
 </table>


### PR DESCRIPTION
Makes last checkin (descending) the default sort.

Still leaves the ability to sort by other columns via JavaScript, but the initial sort is by last checkin (descending). Had to convert to a different date format for the sort to work as well (thanks Graham Gilbert for the link to the ISO format).