### PR TITLE
Add X-Frame-Options setting to Nginx configuration

### DIFF
--- a/docker/nginx/crypt.conf
+++ b/docker/nginx/crypt.conf
@@ -19,5 +19,6 @@ server {
                 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
                 add_header P3P 'CP="ALL DSP COR PSAa PSDa OUR NOR ONL UNI COM NAV"';
                 port_in_redirect off;
+                add_header X-Frame-Options sameorigin;
         }
 }

--- a/docs/Docker.md
+++ b/docs/Docker.md
@@ -90,6 +90,12 @@ It is recommended to use either an Nginx proxy in front of the Crypt app for SSL
 
 _Note Caddy is only free for personal use. For commercial deployments you should build from source yourself or use Nginx._
 
+## X-Frame-Options
+
+The nginx config included with the docker container configures the X-Frame-Options as sameorigin. This protects against a potential attacker using iframes to do bad stuff with Crypt.
+
+Depending on your environment you may need to also configure X-Frame-Options on any proxies in front of Crypt.
+
 ## docker-cimpose
 
 An example `docker-compose.yml` is included. For basic usuage, you should only need to edit the `FIELD_ENCRYPTION_KEY`.


### PR DESCRIPTION
An attacker could potentially put Crypt in an iframe and do bad stuff. By setting `X-Frame-Options` to `sameorigin`, Crypt could only be in a frame hosted on the same origin as crypt.

https://www.keycdn.com/blog/x-frame-options