### PR TITLE
fixed the URL in the approved email

### DIFF
--- a/server/views.py
+++ b/server/views.py
@@ -356,7 +356,7 @@ def approve(request, request_id):
                             request_status,
                             request.user.username,
                             server_name,
-                            reverse("server:secret_info", args=[new_request.id]),
+                            reverse("server:secret_info", args=[new_request.secret.id]),
                         )
                         email_sender = "requests@%s" % request.META["SERVER_NAME"]
                         send_mail(


### PR DESCRIPTION
When clicking on the URLs from approval emails Crypt sends user to a 404 Page not found. As grahamgilbert suggested changing the args to ```args=[new_request.secret.id]```solves this.