### PR TITLE
Set default system locale

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ ENV APP_DIR /home/docker/crypt
 ENV DEBUG false
 ENV LANG en-us
 ENV TZ America/New_York
+ENV LC_ALL en_US.UTF-8
 
 COPY setup/requirements.txt /tmp/requirements.txt
 

--- a/docker/settings_import.py
+++ b/docker/settings_import.py
@@ -61,15 +61,10 @@ elif getenv("TZ"):
 else:
     TIME_ZONE = "America/New_York"
 
-# Read the preferred language code from $LANG, use system locale or
-# set to 'en-us' if neither are set
+# Read the preferred language code from $LANG & default to en-us if not set
+# note django does not support locale-format for LANG
 if getenv("LANG"):
-    if "_" in getenv("LANG"):
-        LANGUAGE_CODE = getenv("LANG")
-    else:
-        LANGUAGE_CODE = "en-us"
-elif locale.getdefaultlocale():
-    LANGUAGE_CODE = locale.getdefaultlocale()[0]
+     LANGUAGE_CODE = getenv("LANG")
 else:
     LANGUAGE_CODE = "en-us"
 

--- a/docker/settings_import.py
+++ b/docker/settings_import.py
@@ -64,7 +64,7 @@ else:
 # Read the preferred language code from $LANG & default to en-us if not set
 # note django does not support locale-format for LANG
 if getenv("LANG"):
-     LANGUAGE_CODE = getenv("LANG")
+    LANGUAGE_CODE = getenv("LANG")
 else:
     LANGUAGE_CODE = "en-us"
 


### PR DESCRIPTION
# Background

Set a system locale to prevent errors such as this due to system locale falling back to use the language setting on devices which don't inherit default locale from the system. 

```shell
  File "/usr/local/lib/python3.7/locale.py", line 587, in getlocale
    return _parse_localename(localename)
  File "/usr/local/lib/python3.7/locale.py", line 495, in _parse_localename
    raise ValueError('unknown locale: %s' % localename)
ValueError: unknown locale: en-US
```

# Further to this 

Removed logic using `LANGUAGE_CODE = locale.getdefaultlocale()[0]` as locales as languages are no longer  supported with django.
 https://github.com/pope1ni/django/blob/5dabb6002ed773c150da4bd3aee756df75d218c2/tests/check_framework/test_translation.py#L23-L31
