### PR TITLE
Add mysql back-end

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN set -ex \
             linux-headers \
             pcre-dev \
             postgresql-dev \
+            mariadb-dev \
             xmlsec-dev \
             tzdata \
     && LIBRARY_PATH=/lib:/usr/lib /bin/sh -c "pip install --no-cache-dir -r /tmp/requirements.txt" \

--- a/docker/settings.py
+++ b/docker/settings.py
@@ -19,6 +19,7 @@ DATABASES = {
 
 host = None
 port = None
+engine = "django.db.backends.postgresql_psycopg2"
 
 if "DB_HOST" in os.environ:
     host = os.environ.get("DB_HOST")
@@ -28,10 +29,13 @@ elif "DB_PORT_5432_TCP_ADDR" in os.environ:
     host = os.environ.get("DB_PORT_5432_TCP_ADDR")
     port = os.environ.get("DB_PORT_5432_TCP_PORT", "5432")
 
+if "DB_ENGINE" in os.environ:
+    engine = os.environ.get("DB_ENGINE")
+
 if host and port:
     DATABASES = {
         "default": {
-            "ENGINE": "django.db.backends.postgresql_psycopg2",
+            "ENGINE": engine,
             "NAME": os.environ["DB_NAME"],
             "USER": os.environ["DB_USER"],
             "PASSWORD": os.environ["DB_PASS"],

--- a/setup/requirements.txt
+++ b/setup/requirements.txt
@@ -20,6 +20,7 @@ isort==4.3.4
 lazy-object-proxy==1.3.1
 mccabe==0.6.1
 meld3==1.0.2
+mysqlclient==1.4.6
 psycopg2==2.7.6.1
 pyasn1==0.1.8
 pycodestyle==2.4.0


### PR DESCRIPTION
Not sure if there is any interest here, but I came across a scenaio where I needed to use mysql as the back-end. The following PR works well in my setup. I am using in docker and set up a new ENV variable to set the backend.

specify `DB_ENGINE=django.db.backends.mysql` along with appropriate db connection info to use mysql back-end. initial mysql database creation not supported.

for example:
```
version: '3'
services:

  crypt:
    image: "sphen/crypt-server-mysql"
    container_name: crypt
    environment:
      - DB_ENGINE=django.db.backends.mysql
      - DB_HOST=xxx.mysql.database.azure.com
      - DB_PORT=3306
      - DB_NAME=crypt
      - DB_USER=crypt@xxx
      - DB_PASS=xxx
    ports:
      - "80:8000"
    restart: always
```