### PR TITLE
Make sure key rotation query filters by computer

### DIFF
--- a/server/views.py
+++ b/server/views.py
@@ -538,7 +538,7 @@ def checkin(request):
     except ValidationError:
         pass
 
-    latest_secret = Secret.objects.filter(secret_type=secret_type).latest(
+    latest_secret = Secret.objects.filter(secret_type=secret_type).filter(computer_id=computer.id).latest(
         "date_escrowed"
     )
     rotation_required = latest_secret.rotation_required


### PR DESCRIPTION
## Details of PR
Right now the key rotation query gets the latest secret filtering only by secret type and not also by computer, which means the latest date escrowed could be the latest for any computer. This leads to some clients getting the instruction to rotate "viewed" recovery keys that aren't actually viewed, and other clients not getting the instruction to rotate a viewed recovery key.

This PR adds in an additional filter to make sure the date secret fetched for `rotation_required` is for the actual machine making the request.

## Testing Done
Database has two secrets, but the latest escrowed in general hasn't had its secret viewed. The second latest escrowed in general has had its secret viewed.
```
SELECT date_escrowed,computer_id, rotation_required FROM server_secret ORDER BY date_escrowed DESC;
date_escrowed|computer_id|rotation_required
2021-07-05 00:04:41.655960|2|0
2021-07-05 00:03:45.864140|1|1
```
### Before the PR
`curl`ing for computer ID 2 returns rotation False:
```
"rotation_required": false}
```
`curl`ing for computer ID 1 also returns rotation False:
```
"rotation_required": false}
```
### After the PR
`curl`ing for computer ID 2 returns rotation False:
```
"rotation_required": false}
```
`curl`ing for computer ID 1 returns rotation True:
```
"rotation_required": true}
```