### PR TITLE
fix: Dockerfile to reduce vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10.8-alpine3.16
+FROM python:3.10.11-alpine3.16
 
 LABEL maintainer="graham@grahamgilbert.com"
 


### PR DESCRIPTION
Hi,

I noticed that there was a newer minor release for the Dockerfile available:
python:3.10.8-alpine3.16 -> python:3.10.11-alpine3.16

The following vulnerabilities are fixed with an upgrade:
- https://snyk.io/vuln/SNYK-ALPINE316-E2FSPROGS-3339843
- https://snyk.io/vuln/SNYK-ALPINE316-EXPAT-6241145
- https://snyk.io/vuln/SNYK-ALPINE316-OPENSSL-3314624
- https://snyk.io/vuln/SNYK-ALPINE316-OPENSSL-3314624
- https://snyk.io/vuln/SNYK-ALPINE316-OPENSSL-3314641