### PR TITLE
Update Docker Build Instructions and Docker Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,8 @@ services:
   #   restart: always
 
   crypt:
-    # image: "macadmins/crypt-server" OR "crypt-server" for local build using documentation in /docs/Docker.md
+    image: macadmins/crypt-server" 
+    # OR "crypt-server" for local build using documentation in /docs/Docker.md
     # build: . # uncomment this to build your own image through Docker Compose
     environment:
       - FIELD_ENCRYPTION_KEY=jKAv1Sde8m6jCYFnmps0iXkUfAilweNVjbvoebBrDwg= # please change this
@@ -24,15 +25,3 @@ services:
       - ${PWD}/crypt.db:/home/app/crypt/crypt.db # This will do a local database. For production you should use postgresql
       - ${PWD}/fvserver/settings.py:/home/app/crypt/fvserver/settings.py # Load in your own settings file
     restart: always
-    
-  nginx:
-    image: nginx:latest
-    container_name: nginx
-    #volumes:
-      #- ./nginx/nginx.conf:/etc/nginx/conf.d/default.conf
-      #- /path/to/certs:/etc/nginx/certs # Update this to point to your SSL certificates
-    ports:
-      - "443:443"
-      - "80:80"
-    depends_on:
-      - crypt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
   #   restart: always
 
   crypt:
-    image: macadmins/crypt-server" 
+    image: macadmins/crypt-server
     # OR "crypt-server" for local build using documentation in /docs/Docker.md
     # build: . # uncomment this to build your own image through Docker Compose
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   # Uncomment here if you want to use Caddy
   # caddy:
@@ -13,8 +12,8 @@ services:
   #   restart: always
 
   crypt:
-    # image: "macadmins/crypt-server"
-    build: . # uncomment this to build your own image and comment out the above
+    # image: "macadmins/crypt-server" OR "crypt-server" for local build using documentation in /docs/Docker.md
+    # build: . # uncomment this to build your own image through Docker Compose
     environment:
       - FIELD_ENCRYPTION_KEY=jKAv1Sde8m6jCYFnmps0iXkUfAilweNVjbvoebBrDwg= # please change this
       - ADMIN_PASS=password
@@ -25,3 +24,15 @@ services:
       - ${PWD}/crypt.db:/home/app/crypt/crypt.db # This will do a local database. For production you should use postgresql
       - ${PWD}/fvserver/settings.py:/home/app/crypt/fvserver/settings.py # Load in your own settings file
     restart: always
+    
+  nginx:
+    image: nginx:latest
+    container_name: nginx
+    #volumes:
+      #- ./nginx/nginx.conf:/etc/nginx/conf.d/default.conf
+      #- /path/to/certs:/etc/nginx/certs # Update this to point to your SSL certificates
+    ports:
+      - "443:443"
+      - "80:80"
+    depends_on:
+      - crypt

--- a/docs/Docker.md
+++ b/docs/Docker.md
@@ -1,14 +1,59 @@
 # Using Docker
 
+## Server Initialization
+This was last tested on Ubuntu 24.04 x86
+
+``` bash
+git clone https://github.com/grahamgilbert/Crypt-Server.git
+```
+
+Install Docker and Docker Compose plugin following instructions here:
+``` bash
+https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository
+```
+
+Restart the Docker services
+``` bash
+sudo systemctl restart docker
+```
+
+Ensure docker permissions are set. Log out then back in after running this command: 
+``` bash
+sudo usermod -aG docker $USER
+```
+
+We will now install the Docker buildx plugin. 
+``` bash
+sudo apt install docker-buildx
+```
+
+Verify plugin state: 
+``` bash
+docker info | head -n8
+```
+
+Response should be similar to: 
+``` bash
+Client:
+ Version:    24.0.7
+ Context:    default
+ Debug Mode: false
+ Plugins:
+  buildx: Docker Buildx (Docker Inc.)
+    Version:  0.12.1
+    Path:     /usr/libexec/docker/cli-plugins/docker-buildx
+```
+
+Build the Dockerfile:
+``` bash
+docker buildx build -t crypt-server .
+```
+
 ## Prepare for first use
 When starting from scratch, create a new empty file on the docker host to hold the sqlite3 secrets database
 ``` bash
 touch /somewhere/else/on/the/host
 ```
-
-## Upgrading from Crypt Server 2
-
-The encryption method has changed in Crypt Server. You should pass in both your old encryption keys (e.g. `-v /somewhere/on/the/host:/home/docker/crypt/keyset`) and the new one (see below) for the first run to migrate your keys. After the migration you no longer need your old encryption keys. Crypt 3 is a major update, you should ensure any custom settings you pass are still valid.
 
 ## Basic usage
 ``` bash
@@ -17,8 +62,19 @@ docker run -d --name="Crypt" \
 -v /somewhere/else/on/the/host:/home/docker/crypt/crypt.db \
 -e FIELD_ENCRYPTION_KEY='yourencryptionkey' \
 -p 8000:8000 \
-macadmins/crypt-server
+crypt-server
 ```
+
+## Verify Operation
+``` bash
+docker logs Crypt
+```
+
+## Upgrading from Crypt Server 2
+
+The encryption method has changed in Crypt Server. You should pass in both your old encryption keys (e.g. `-v /somewhere/on/the/host:/home/docker/crypt/keyset`) and the new one (see below) for the first run to migrate your keys. After the migration you no longer need your old encryption keys. Crypt 3 is a major update, you should ensure any custom settings you pass are still valid.
+
+
 
 The secrets are encrypted, with the encryption key passed in as an environment variable. You should back this up as the keys are not recoverable without them.
 

--- a/docs/Docker.md
+++ b/docs/Docker.md
@@ -2,6 +2,7 @@
 
 ## Server Initialization
 This was last tested on Ubuntu 24.04 x86
+Note: For this document, macadmins/crypt-server and crypt-server are used interchangeably. macadmins/crypt-server references the downloadedy option and crypt-server represents the local build option. 
 
 ``` bash
 git clone https://github.com/grahamgilbert/Crypt-Server.git

--- a/docs/Docker.md
+++ b/docs/Docker.md
@@ -1,8 +1,7 @@
 # Using Docker
 
 ## Server Initialization
-This was last tested on Ubuntu 24.04 x86
-Note: For this document, macadmins/crypt-server and crypt-server are used interchangeably. macadmins/crypt-server references the downloadedy option and crypt-server represents the local build option. 
+This was last tested on Ubuntu 24.04 x86. This process may need to be modified for older installations.
 
 ``` bash
 git clone https://github.com/grahamgilbert/Crypt-Server.git
@@ -23,33 +22,6 @@ Ensure docker permissions are set. Log out then back in after running this comma
 sudo usermod -aG docker $USER
 ```
 
-We will now install the Docker buildx plugin. 
-``` bash
-sudo apt install docker-buildx
-```
-
-Verify plugin state: 
-``` bash
-docker info | head -n8
-```
-
-Response should be similar to: 
-``` bash
-Client:
- Version:    24.0.7
- Context:    default
- Debug Mode: false
- Plugins:
-  buildx: Docker Buildx (Docker Inc.)
-    Version:  0.12.1
-    Path:     /usr/libexec/docker/cli-plugins/docker-buildx
-```
-
-Build the Dockerfile:
-``` bash
-docker buildx build -t crypt-server .
-```
-
 ## Prepare for first use
 When starting from scratch, create a new empty file on the docker host to hold the sqlite3 secrets database
 ``` bash
@@ -63,7 +35,7 @@ docker run -d --name="Crypt" \
 -v /somewhere/else/on/the/host:/home/docker/crypt/crypt.db \
 -e FIELD_ENCRYPTION_KEY='yourencryptionkey' \
 -p 8000:8000 \
-crypt-server
+macadmins/crypt-server
 ```
 
 ## Verify Operation


### PR DESCRIPTION
This pull request represents the following changes:
Updates documentation to reflect build tested to work on Ubuntu 24.04 x86 (Removed references but kept compliant syntax in Docker Compose)
- Migrates build to Docker build (Deprecated this out of PR)
- Migrates Docker Compose v1 application to Docker Compose v2 plugin (KEPT)
- Changes docker-compose.yml syntax to be v2 complaint (KEPT)
- Adds nginx proxy option to Docker-compose file to present Crypt on the network (Deprecated this out of PR)

Incorporates changes proposed on https://github.com/grahamgilbert/Crypt-Server/pull/131 to fix 1 vulnerability by pinning transitive dependencies:

https://snyk.io/vuln/SNYK-PYTHON-SELENIUM-6062316