### PR TITLE
Black Linter Update + Formatting Fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,7 @@ jobs:
             . .venv/bin/activate
             cp fvserver/example_settings.py fvserver/settings.py
             # python manage.py test
+            python -c 'import os; print(os.getenv("FIELD_ENCRYPTION_KEY"))'
             python manage.py migrate
       - run:
           name: run linting

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,6 @@ jobs:
             . .venv/bin/activate
             cp fvserver/example_settings.py fvserver/settings.py
             # python manage.py test
-            python -c 'import os; print(os.getenv("FIELD_ENCRYPTION_KEY"))'
             python manage.py migrate
       - run:
           name: run linting

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       # Please change FIELD_ENCRYPTION_KEY by running 
       # from cryptography.fernet import Fernet
       # key = Fernet.generate_key()
-      - FIELD_ENCRYPTION_KEY='Og6yJ3Gdf-ROlUOkdxiS2d5Km_JGTDnfyJEXXQ15TY8='
+      - FIELD_ENCRYPTION_KEY=Og6yJ3Gdf-ROlUOkdxiS2d5Km_JGTDnfyJEXXQ15TY8=
       - ADMIN_PASS=password
       - DEBUG=false
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       # Please change FIELD_ENCRYPTION_KEY by running 
       # from cryptography.fernet import Fernet
       # key = Fernet.generate_key()
-      - FIELD_ENCRYPTION_KEY=Og6yJ3Gdf-ROlUOkdxiS2d5Km_JGTDnfyJEXXQ15TY8=
+      - FIELD_ENCRYPTION_KEY=aktBdjFTZGU4bTZqQ1lGbm1wczBpWGtVZkFpbHdlTlZqYnZvZWJCckR3Zz0=
       - ADMIN_PASS=password
       - DEBUG=false
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,10 +16,7 @@ services:
     # OR "crypt-server" for local build using documentation in /docs/Docker.md
     # build: . # uncomment this to build your own image through Docker Compose
     environment:
-      # Please change FIELD_ENCRYPTION_KEY by running 
-      # from cryptography.fernet import Fernet
-      # key = Fernet.generate_key()
-      - FIELD_ENCRYPTION_KEY="b'BIXIqOVKmE7m_H4qMz3bgAR9x8SgWRhx8EiWuHOB6ro='"
+      - FIELD_ENCRYPTION_KEY=jKAv1Sde8m6jCYFnmps0iXkUfAilweNVjbvoebBrDwg= # please change this
       - ADMIN_PASS=password
       - DEBUG=false
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     # OR "crypt-server" for local build using documentation in /docs/Docker.md
     # build: . # uncomment this to build your own image through Docker Compose
     environment:
-      - FIELD_ENCRYPTION_KEY=jKAv1Sde8m6jCYFnmps0iXkUfAilweNVjbvoebBrDwg= # please change this
+      - FIELD_ENCRYPTION_KEY=Og6yJ3Gdf-ROlUOkdxiS2d5Km_JGTDnfyJEXXQ15TY8= # please change this
       - ADMIN_PASS=password
       - DEBUG=false
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,10 @@ services:
     # OR "crypt-server" for local build using documentation in /docs/Docker.md
     # build: . # uncomment this to build your own image through Docker Compose
     environment:
-      - FIELD_ENCRYPTION_KEY=Og6yJ3Gdf-ROlUOkdxiS2d5Km_JGTDnfyJEXXQ15TY8= # please change this
+      # Please change FIELD_ENCRYPTION_KEY by running 
+      # from cryptography.fernet import Fernet
+      # key = Fernet.generate_key()
+      - FIELD_ENCRYPTION_KEY="Og6yJ3Gdf-ROlUOkdxiS2d5Km_JGTDnfyJEXXQ15TY8=" 
       - ADMIN_PASS=password
       - DEBUG=false
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       # Please change FIELD_ENCRYPTION_KEY by running 
       # from cryptography.fernet import Fernet
       # key = Fernet.generate_key()
-      - FIELD_ENCRYPTION_KEY=aktBdjFTZGU4bTZqQ1lGbm1wczBpWGtVZkFpbHdlTlZqYnZvZWJCckR3Zz0=
+      - FIELD_ENCRYPTION_KEY="b'BIXIqOVKmE7m_H4qMz3bgAR9x8SgWRhx8EiWuHOB6ro='"
       - ADMIN_PASS=password
       - DEBUG=false
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       # Please change FIELD_ENCRYPTION_KEY by running 
       # from cryptography.fernet import Fernet
       # key = Fernet.generate_key()
-      - FIELD_ENCRYPTION_KEY="Og6yJ3Gdf-ROlUOkdxiS2d5Km_JGTDnfyJEXXQ15TY8=" 
+      - FIELD_ENCRYPTION_KEY='Og6yJ3Gdf-ROlUOkdxiS2d5Km_JGTDnfyJEXXQ15TY8='
       - ADMIN_PASS=password
       - DEBUG=false
     ports:

--- a/docker/django/management/commands/update_admin_user.py
+++ b/docker/django/management/commands/update_admin_user.py
@@ -9,6 +9,7 @@ from optparse import make_option
 
 class Command(BaseCommand):
     help = "Creates/Updates an Admin user"
+
     # option_list = BaseCommand.option_list + (
     #     make_option('--username',
     #         action='store',

--- a/fvserver/wsgi.py
+++ b/fvserver/wsgi.py
@@ -13,6 +13,7 @@ middleware here, or combine a Django application with an application of another
 framework.
 
 """
+
 import os
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "fvserver.settings")

--- a/server/models.py
+++ b/server/models.py
@@ -5,6 +5,7 @@ from encrypted_model_fields.fields import EncryptedCharField
 
 from django.core.exceptions import ValidationError
 
+
 # Create your models here.
 class Computer(models.Model):
     # recovery_key = models.CharField(max_length=200, verbose_name="Recovery Key")

--- a/server/views.py
+++ b/server/views.py
@@ -23,6 +23,7 @@ from django.utils.html import escape
 # Create your views here.
 logger = logging.getLogger(__name__)
 
+
 ##clean up old requests
 def cleanup():
     how_many_days = 7

--- a/setup/requirements.txt
+++ b/setup/requirements.txt
@@ -4,7 +4,7 @@ asn1crypto==1.5.1
 astroid==2.12.11
 attrs==22.1.0
 beautifulsoup4==4.11.1
-black==22.10.0
+black==24.3.0
 cffi==1.15.0
 click==8.1.3
 cryptography==41.0.2


### PR DESCRIPTION
Hi,

I updated Black to resolve [Regular Expression Denial of Service (ReDoS)](https://learn.snyk.io/lesson/redos/?loc=fix-pr) vulnerability.

This required updating the formatting of a few files to pass linting since it would throw:

```
would reformat /home/circleci/repo/docker/django/management/commands/update_admin_user.py
would reformat /home/circleci/repo/fvserver/wsgi.py
would reformat /home/circleci/repo/server/models.py
would reformat /home/circleci/repo/server/views.py

Oh no! 💥 💔 💥
4 files would be reformatted, 42 files would be left unchanged.
```

