### PR TITLE
Format `docker/settings.py` with `black`

### DIFF
--- a/docker/settings.py
+++ b/docker/settings.py
@@ -42,33 +42,40 @@ if host and port:
         }
     }
 
-if 'AWS_IAM' in os.environ:
+if "AWS_IAM" in os.environ:
     import requests
-    cert_bundle_url = 'https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem'
-    cert_target_path = '/etc/ssl/certs/global-bundle.pem'
+
+    cert_bundle_url = (
+        "https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem"
+    )
+    cert_target_path = "/etc/ssl/certs/global-bundle.pem"
 
     response = requests.get(cert_bundle_url)
     if response.status_code == 200:
         os.makedirs(os.path.dirname(cert_target_path), exist_ok=True)
 
-        with open(cert_target_path, 'wb') as file:
+        with open(cert_target_path, "wb") as file:
             file.write(response.content)
-        print(f"AWS RDS cert bundle successfully downloaded and saved to {cert_target_path}")
+        print(
+            f"AWS RDS cert bundle successfully downloaded and saved to {cert_target_path}"
+        )
     else:
-        print(f"Failed to download AWS RDS cert bundle, status code: {response.status_code}")
+        print(
+            f"Failed to download AWS RDS cert bundle, status code: {response.status_code}"
+        )
     DATABASES = {
-        'default': {
-            'ENGINE': 'django_iam_dbauth.aws.postgresql',
-            'NAME': os.environ['DB_NAME'],
-            'USER': os.environ['DB_USER'],
-            'HOST': os.environ['DB_HOST'],
-            'PORT': os.environ['DB_PORT'],
-            'OPTIONS': {
-                'region_name': os.environ['AWS_RDS_REGION'],
-                'sslmode': 'verify-full',
-                'sslrootcert': '/etc/ssl/certs/global-bundle.pem',
-                'use_iam_auth': True,
-            }
+        "default": {
+            "ENGINE": "django_iam_dbauth.aws.postgresql",
+            "NAME": os.environ["DB_NAME"],
+            "USER": os.environ["DB_USER"],
+            "HOST": os.environ["DB_HOST"],
+            "PORT": os.environ["DB_PORT"],
+            "OPTIONS": {
+                "region_name": os.environ["AWS_RDS_REGION"],
+                "sslmode": "verify-full",
+                "sslrootcert": "/etc/ssl/certs/global-bundle.pem",
+                "use_iam_auth": True,
+            },
         }
     }
 


### PR DESCRIPTION
[ Note: This should be merged _before_ [crypt-server-saml/pull/17](https://github.com/grahamgilbert/crypt-server-saml/pull/17) ]

Ran `black` on my fork:
```
$ black --version
black, 24.10.0 (compiled: no)
Python (CPython) 3.13.0
$ 
$ black ./settings.py
reformatted settings.py

All done! ✨ 🍰 ✨
1 file reformatted.
$ 
```

This should fix the [build failure](https://app.circleci.com/pipelines/github/grahamgilbert/Crypt-Server/203/workflows/7f5e3880-d905-4a7d-b821-42361110bcad/jobs/364/parallel-runs/0/steps/0-106) where `black` found formatting issues in `docker/settings.py`. 

In turn, this will hopefully trigger a new `latest` tag being pushed to Docker Hub.