### PR TITLE
bump asgiref to 3.6.0

### DIFF
--- a/setup/requirements.txt
+++ b/setup/requirements.txt
@@ -1,5 +1,5 @@
 appdirs==1.4.4
-asgiref==3.5.2
+asgiref==3.6.0
 asn1crypto==1.5.1
 astroid==2.12.11
 attrs==22.1.0


### PR DESCRIPTION
encountered an error when building with the updated django which was committed. in order to get it to build, i bumped asgiref to 3.6.0. not sure if we should go further as they are up to 3.8.1 now.

```
#9 7.207 ERROR: Cannot install -r /tmp/requirements.txt (line 11) and asgiref==3.5.2 because these package versions have conflicting dependencies.
#9 7.207 
#9 7.207 The conflict is caused by:
#9 7.207     The user requested asgiref==3.5.2
#9 7.207     django 4.2.18 depends on asgiref<4 and >=3.6.0
```