### PR TITLE
Display whether escrowed secret is newly created or not

### DIFF
--- a/server/views.py
+++ b/server/views.py
@@ -540,6 +540,8 @@ def checkin(request):
     computer.secret_type = secret_type
     computer.save()
 
+    newly_created = True
+
     try:
         secret = Secret(
             computer=computer,
@@ -549,6 +551,7 @@ def checkin(request):
         )
         secret.save()
     except ValidationError:
+        newly_created = False
         pass
 
     latest_secret = (
@@ -562,5 +565,6 @@ def checkin(request):
         "serial": computer.serial,
         "username": computer.username,
         "rotation_required": rotation_required,
+        "newly_created": newly_created,
     }
     return HttpResponse(json.dumps(c), content_type="application/json")

--- a/server/views.py
+++ b/server/views.py
@@ -540,7 +540,7 @@ def checkin(request):
     computer.secret_type = secret_type
     computer.save()
 
-    newly_created = True
+    new_secret_escrowed = True
 
     try:
         secret = Secret(
@@ -551,7 +551,7 @@ def checkin(request):
         )
         secret.save()
     except ValidationError:
-        newly_created = False
+        new_secret_escrowed = False
         pass
 
     latest_secret = (
@@ -565,6 +565,6 @@ def checkin(request):
         "serial": computer.serial,
         "username": computer.username,
         "rotation_required": rotation_required,
-        "newly_created": newly_created,
+        "new_secret_escrowed": new_secret_escrowed,
     }
     return HttpResponse(json.dumps(c), content_type="application/json")


### PR DESCRIPTION
## Details of PR
This obviously isn't necessary for core functionality, but it is just more interesting information to get back when escrowing a key (is it a new key, or are you just escrowing the old one again?).

## Testing Done
First time escrowing returns `true` for `newly_created`:
```
NAMEOFHOST:~$ curl -d "serial=ACTUALSERIALNUMB&secret_type=recovery_key&recovery_password=NEWRECOVERYKEY2&username=ACTUALUSERNAME"  http://localhost:8000/checkin/
{"serial": "ACTUALSERIALNUMB", "username": "ACTUALUSERNAME", "rotation_required": false, "newly_created": true}
```
Subsequent escrows return `false`:
```
NAMEOFHOST:~$ curl -d "serial=ACTUALSERIALNUMB&secret_type=recovery_key&recovery_password=NEWRECOVERYKEY2&username=ACTUALUSERNAME"  http://localhost:8000/checkin/
{"serial": "ACTUALSERIALNUMB", "username": "ACTUALUSERNAME", "rotation_required": false, "newly_created": false}
NAMEOFHOST:~$ curl -d "serial=ACTUALSERIALNUMB&secret_type=recovery_key&recovery_password=NEWRECOVERYKEY2&username=ACTUALUSERNAME"  http://localhost:8000/checkin/
{"serial": "ACTUALSERIALNUMB", "username": "ACTUALUSERNAME", "rotation_required": false, "newly_created": false}
```
Same happens for another key:
```
NAMEOFHOST:~$ curl -d "serial=ACTUALSERIALNUMB&secret_type=recovery_key&recovery_password=NEWRECOVERYKEY3&username=ACTUALUSERNAME"  http://localhost:8000/checkin/
{"serial": "ACTUALSERIALNUMB", "username": "ACTUALUSERNAME", "rotation_required": false, "newly_created": true}
NAMEOFHOST:~$ curl -d "serial=ACTUALSERIALNUMB&secret_type=recovery_key&recovery_password=NEWRECOVERYKEY3&username=ACTUALUSERNAME"  http://localhost:8000/checkin/
{"serial": "ACTUALSERIALNUMB", "username": "ACTUALUSERNAME", "rotation_required": false, "newly_created": false}
```
In total, only two key entries:
<img width="1026" height="646" alt="Screenshot 2026-01-01 at 23 01 27" src="https://github.com/user-attachments/assets/8d67db34-503b-4720-9749-05d0c3f8cc34" />
