### PR TITLE
Fix the build, keep the FIELD_ENCRYPTION_KEY literal out of the image, bump to 3.4.2

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,23 @@ keyset/
 *.db
 *.pyc
 crypt.db*
+
+# Build- and dev-time only. `COPY / $APP_DIR` would otherwise ship all of this
+# inside the runtime image, including the throwaway FIELD_ENCRYPTION_KEY in
+# docker-compose.yml and the host-side docker/run_docker*.sh helpers.
+.git/
+.gitignore
+.circleci/
+.pre-commit-config.yaml
+.flake8
+Dockerfile
+.dockerignore
+docker-compose.yml
+docker/run_docker.sh
+docker/run_docker_postgres.sh
+docker/postgres.sh
+docker/setup_db.sh
+smtp.sh
+remote_build.py
+set_build_no.py
+functional_tests/

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,8 +45,11 @@ RUN chmod +x /run.sh \
     && ln -s ${APP_DIR} /home/app/crypt
 
 WORKDIR ${APP_DIR}
-# don't use this key anywhere else, this is just for collectstatic to run
-RUN export FIELD_ENCRYPTION_KEY="jKAv1Sde8m6jCYFnmps0iXkUfAilweNVjbvoebBrDwg="; python manage.py collectstatic --noinput; export FIELD_ENCRYPTION_KEY=""
+# collectstatic imports the app, which needs a key present to load the encrypted
+# fields. Generate a throwaway one for this build step only, so no key literal
+# ends up in the image, the layer, or `docker history`.
+RUN FIELD_ENCRYPTION_KEY="$(python -c 'import base64, os; print(base64.urlsafe_b64encode(os.urandom(32)).decode())')" \
+    python manage.py collectstatic --noinput
 
 EXPOSE 8000
 

--- a/set_build_no.py
+++ b/set_build_no.py
@@ -4,7 +4,7 @@ import os
 import plistlib
 import subprocess
 
-current_version = "3.4.1"
+current_version = "3.4.2"
 script_path = os.path.dirname(os.path.realpath(__file__))
 
 

--- a/setup/requirements.txt
+++ b/setup/requirements.txt
@@ -1,5 +1,5 @@
 appdirs==1.4.4
-asgiref==3.5.2
+asgiref==3.12.1
 asn1crypto==1.5.1
 astroid==2.12.11
 attrs==22.1.0


### PR DESCRIPTION
Three changes: the first fixes the Docker build, which is currently broken on `master`, the second stops the published images from carrying a hardcoded encryption key, and the third bumps the version to cover both.

## 1. `asgiref` pin blocks the build

`setup/requirements.txt` pins `asgiref==3.5.2`, but Django was bumped to 4.2.28, which requires `asgiref>=3.6.0,<4`. pip can't resolve that, so `docker build` fails at the pip install step:

```
ERROR: Cannot install -r /tmp/requirements.txt (line 11) and asgiref==3.5.2
       because these package versions have conflicting dependencies.
    django 4.2.28 depends on asgiref<4 and >=3.6.0
```

I confirmed this on unmodified `master` (509a168), so it isn't caused by anything else here. Bumped to `3.12.1`, the newest 3.x — it needs Python >=3.10, which `python:3.10.11-alpine3.16` satisfies.

## 2. The placeholder encryption key ends up inside every image

`COPY / $APP_DIR` ships the whole repo into the runtime image, so the placeholder `FIELD_ENCRYPTION_KEY` in `docker-compose.yml` and `docker/run_docker*.sh` is present in the published `crypt-server` images, along with the git history, CI config, and functional tests. Cloud security scanners flag it as a cleartext secret whenever the container is reachable from the internet, which takes a while to run down because the value looks live.

The key in the `Dockerfile` is a second copy of the same problem. Even though it's only needed for `collectstatic`, the literal is recorded in that layer's `RUN` string and stays visible in `docker history` — so ignoring the file wouldn't have been enough on its own.

- **`.dockerignore`**: drop build- and dev-only paths from the context. The host-side helpers (`run_docker.sh`, `run_docker_postgres.sh`, `postgres.sh`, `setup_db.sh`) go too — they invoke `docker run` from the host so they can't work inside the container, and they carry the key and `DB_PASS=password` literals.
- **`Dockerfile`**: generate a throwaway key for the `collectstatic` step instead of hardcoding one. `base64(os.urandom(32))` matches the format `django-encrypted-model-fields` expects and is accepted by `Fernet`. The old trailing `export FIELD_ENCRYPTION_KEY=""` was a no-op anyway, since each `RUN` is its own shell.

No behaviour change at runtime: `FIELD_ENCRYPTION_KEY` was never in the image's `Config.Env` (the old `RUN export` didn't persist), so deployments have always had to supply their own key. The build-time value is used only to let `collectstatic` import the app — there's no database at build time, so nothing is ever encrypted with it.

Nothing the build needs was dropped. `setup/requirements.txt`, `docker/settings.py`, `docker/settings_import.py`, `docker/gunicorn_config.py`, `docker/django/management/` and `docker/run.sh` are all still in the context for their `COPY` steps. `fvserver/version.plist` is committed and still ships, so the version shown by `context_processors.py` and `server/views.py` is unaffected — `set_build_no.py` runs before `docker build`, not inside it.

## 3. Version bump to 3.4.2

`set_build_no.py` was still on `3.4.1`, matching the latest tag. Bumped to `3.4.2` to cover the two changes above. Left `fvserver/version.plist` alone since CI regenerates it, matching how the 3.4.0 → 3.4.1 bump was done.

Note that excluding `set_build_no.py` from the build context doesn't affect this: it runs before `docker build` and writes `version.plist` into the checkout, and that file is committed and copied into the image.

## Verification

Built the image from this branch and ran it:

- build completes, all 13 stages, `collectstatic` copies 187 files
- no `jKAv1Sde...`, `DB_PASS=password` or `ADMIN_PASS=pass` anywhere under `$APP_DIR` or in `/run.sh`
- zero matches for the key in `docker history`
- `manage.py check` — no issues
- container started via its own `CMD`: gunicorn boots, `GET /` → 302 → `/login/`, `GET /login/` → 200, no restarts

The runtime test used a key different from the build-time one, which shows the two are independent.

## One thing I left alone

`docker-compose.yml` still has the placeholder key in the repo. It's out of the image now, but anyone running `docker compose up` unchanged is still escrowing recovery keys under a publicly known key. Making that fail closed (e.g. `${FIELD_ENCRYPTION_KEY:?generate one first}`) would be a nice follow-up, but it changes the quickstart experience, so that felt like your call rather than something to slip in here.